### PR TITLE
Updated types to match native code

### DIFF
--- a/components/Types/ViroUtils.ts
+++ b/components/Types/ViroUtils.ts
@@ -31,6 +31,15 @@ export type ViroRotation = [
 ];
 
 /**
+ * 3D Vector, stored as [x, y, z].
+ */
+export type Viro3DVector = [
+  number, // x component
+  number, // y component
+  number // z component
+];
+
+/**
  * The scale of the container in 3D space, specified as [x,y,z]. A scale of
  * 1 represents the current size of the container. A scale value of < 1
  * will make the container proportionally smaller while a value >1 will make
@@ -98,19 +107,18 @@ export type ViroPhysicsBody = {
    * If an array of forces is provided, the corresponding net force will be applied.
    * Force units are in newtons.
    */
-  force?: number[];
+  force?: ViroForce[];
   /**
-   * A single torque vector or an array of torque vectors applied to the physics body.
-   * If an array of torque is provided, the corresponding net torque will be applied.
+   * A single 3D torque vector applied to the physics body.
    * Torque units are in newton meters.
    */
-  torque?: number[];
+  torque?: ViroTorque;
   /**
    * Used to directly move an object without applying a force.
    * Units are m/s. Doing so will override any forces that are already
    * applied on this physics body.
    */
-  velocity?: number[];
+  velocity?: Viro3DVector;
 };
 
 export type ViroPhysicsBodyType = "Dynamic" | "Kinematic" | "Static";
@@ -123,13 +131,12 @@ export type ViroPhysicsBodyShape = {
 export type ViroPhysicsBodyShapeType = "Box" | "Sphere" | "Compound";
 
 /**
- * A single force vector or an array of force vectors applied to the physics body.
- * If an array of forces is provided, the corresponding net force will be applied.
+ * A single force vector applied to the physics body.
  * Force units are in newtons.
  */
 export type ViroForce = {
-  value: Array<number>;
-  position: Array<number>;
+  value: Viro3DVector;
+  position: Viro3DPoint;
 };
 
 export type ViroSource = ImageSourcePropType;
@@ -145,15 +152,19 @@ export type ViroSoundRoom = {
 };
 
 export type ViroPhysicsWorld = {
-  gravity: number;
+  gravity: Viro3DVector;
   drawBounds?: boolean;
 };
 
-export type ViroRay = any;
+export type ViroRay = Viro3DVector;
 
-export type ViroTorque = any;
+/**
+ * A single 3D torque vector applied to the physics body.
+ * Torque units are in newton meters.
+ */
+export type ViroTorque = Viro3DVector;
 
-export type ViroVelocity = any;
+export type ViroVelocity = Viro3DVector;
 
 export type Viro2DPoint = [number, number];
 

--- a/components/ViroBase.tsx
+++ b/components/ViroBase.tsx
@@ -157,11 +157,11 @@ export class ViroBase<T> extends React.Component<ViroBaseProps & T> {
     );
   };
 
-  applyImpulse = (force: ViroForce, position: Viro3DPoint) => {
+  applyImpulse = (force: ViroForce) => {
     NativeModules.VRTNodeModule.applyImpulse(
       findNodeHandle(this),
-      force,
-      position
+      force.value,
+      force.position
     );
   };
 

--- a/components/ViroButton.tsx
+++ b/components/ViroButton.tsx
@@ -83,8 +83,8 @@ export class ViroButton extends React.Component<Props, State> {
     buttonType: ViroButtonStateTypes.BTN_TYPE_NORMAL,
   };
 
-  applyImpulse = (force: ViroForce, atPosition: Viro3DPoint) => {
-    this._component?.applyImpulse(force, atPosition);
+  applyImpulse = (force: ViroForce) => {
+    this._component?.applyImpulse(force);
   };
 
   applyTorqueImpulse = (torque: ViroTorque) => {

--- a/dist/components/Types/ViroUtils.d.ts
+++ b/dist/components/Types/ViroUtils.d.ts
@@ -25,6 +25,14 @@ export type ViroRotation = [
     number
 ];
 /**
+ * 3D Vector, stored as [x, y, z].
+ */
+export type Viro3DVector = [
+    number,
+    number,
+    number
+];
+/**
  * The scale of the container in 3D space, specified as [x,y,z]. A scale of
  * 1 represents the current size of the container. A scale value of < 1
  * will make the container proportionally smaller while a value >1 will make
@@ -88,19 +96,18 @@ export type ViroPhysicsBody = {
      * If an array of forces is provided, the corresponding net force will be applied.
      * Force units are in newtons.
      */
-    force?: number[];
+    force?: ViroForce[];
     /**
-     * A single torque vector or an array of torque vectors applied to the physics body.
-     * If an array of torque is provided, the corresponding net torque will be applied.
+     * A single 3D torque vector applied to the physics body.
      * Torque units are in newton meters.
      */
-    torque?: number[];
+    torque?: ViroTorque;
     /**
      * Used to directly move an object without applying a force.
      * Units are m/s. Doing so will override any forces that are already
      * applied on this physics body.
      */
-    velocity?: number[];
+    velocity?: Viro3DVector;
 };
 export type ViroPhysicsBodyType = "Dynamic" | "Kinematic" | "Static";
 export type ViroPhysicsBodyShape = {
@@ -109,13 +116,12 @@ export type ViroPhysicsBodyShape = {
 };
 export type ViroPhysicsBodyShapeType = "Box" | "Sphere" | "Compound";
 /**
- * A single force vector or an array of force vectors applied to the physics body.
- * If an array of forces is provided, the corresponding net force will be applied.
+ * A single force vector applied to the physics body.
  * Force units are in newtons.
  */
 export type ViroForce = {
-    value: Array<number>;
-    position: Array<number>;
+    value: Viro3DVector;
+    position: Viro3DPoint;
 };
 export type ViroSource = ImageSourcePropType;
 export type ViroARPlaneType = any;
@@ -126,12 +132,16 @@ export type ViroSoundRoom = {
     floorMaterial: string;
 };
 export type ViroPhysicsWorld = {
-    gravity: number;
+    gravity: Viro3DVector;
     drawBounds?: boolean;
 };
-export type ViroRay = any;
-export type ViroTorque = any;
-export type ViroVelocity = any;
+export type ViroRay = Viro3DVector;
+/**
+ * A single 3D torque vector applied to the physics body.
+ * Torque units are in newton meters.
+ */
+export type ViroTorque = Viro3DVector;
+export type ViroVelocity = Viro3DVector;
 export type Viro2DPoint = [number, number];
 export type ViroUVCoordinate = [number, number, number, number];
 export type ViroSoundMap = {

--- a/dist/components/ViroBase.d.ts
+++ b/dist/components/ViroBase.d.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 import { NativeSyntheticEvent } from "react-native";
 import { ViroCommonProps, ViroObjectProps } from "./AR/ViroCommonProps";
 import { ViroHoverEvent, ViroClickEvent, ViroClickStateEvent, ViroTouchEvent, ViroScrollEvent, ViroSwipeEvent, ViroPinchEvent, ViroRotateEvent, ViroDragEvent, ViroFuseEvent, ViroAnimationStartEvent, ViroAnimationFinishEvent, ViroCollisionEvent, ViroNativeTransformUpdateEvent, ViroErrorEvent } from "./Types/ViroEvents";
-import { ViroNativeRef, ViroForce, Viro3DPoint, ViroTorque, ViroVelocity } from "./Types/ViroUtils";
+import { ViroNativeRef, ViroForce, ViroTorque, ViroVelocity } from "./Types/ViroUtils";
 export type ViroBaseProps = ViroCommonProps & ViroObjectProps;
 export declare class ViroBase<T> extends React.Component<ViroBaseProps & T> {
     _component: ViroNativeRef;
@@ -21,7 +21,7 @@ export declare class ViroBase<T> extends React.Component<ViroBaseProps & T> {
     _onError: (event: NativeSyntheticEvent<ViroErrorEvent>) => void;
     getTransformAsync: () => Promise<any>;
     getBoundingBoxAsync: () => Promise<any>;
-    applyImpulse: (force: ViroForce, position: Viro3DPoint) => void;
+    applyImpulse: (force: ViroForce) => void;
     applyTorqueImpulse: (torque: ViroTorque) => void;
     setVelocity: (velocity: ViroVelocity) => void;
     _onCollision: (event: NativeSyntheticEvent<ViroCollisionEvent>) => void;

--- a/dist/components/ViroBase.js
+++ b/dist/components/ViroBase.js
@@ -109,8 +109,8 @@ class ViroBase extends React.Component {
     getBoundingBoxAsync = async () => {
         return await react_native_1.NativeModules.VRTNodeModule.getBoundingBox((0, react_native_1.findNodeHandle)(this));
     };
-    applyImpulse = (force, position) => {
-        react_native_1.NativeModules.VRTNodeModule.applyImpulse((0, react_native_1.findNodeHandle)(this), force, position);
+    applyImpulse = (force) => {
+        react_native_1.NativeModules.VRTNodeModule.applyImpulse((0, react_native_1.findNodeHandle)(this), force.value, force.position);
     };
     applyTorqueImpulse = (torque) => {
         react_native_1.NativeModules.VRTNodeModule.applyTorqueImpulse((0, react_native_1.findNodeHandle)(this), torque);

--- a/dist/components/ViroButton.d.ts
+++ b/dist/components/ViroButton.d.ts
@@ -47,7 +47,7 @@ export declare class ViroButton extends React.Component<Props, State> {
     state: {
         buttonType: ViroButtonStateTypes;
     };
-    applyImpulse: (force: ViroForce, atPosition: Viro3DPoint) => void;
+    applyImpulse: (force: ViroForce) => void;
     applyTorqueImpulse: (torque: ViroTorque) => void;
     setVelocity: (velocity: ViroVelocity) => void;
     _onAnimationStart: () => void;

--- a/dist/components/ViroButton.js
+++ b/dist/components/ViroButton.js
@@ -64,8 +64,8 @@ class ViroButton extends React.Component {
     state = {
         buttonType: ViroButtonStateTypes.BTN_TYPE_NORMAL,
     };
-    applyImpulse = (force, atPosition) => {
-        this._component?.applyImpulse(force, atPosition);
+    applyImpulse = (force) => {
+        this._component?.applyImpulse(force);
     };
     applyTorqueImpulse = (torque) => {
         this._component?.applyTorqueImpulse(torque);


### PR DESCRIPTION
I found some error for the property force of physicsBody prop, when doing what the ts linter told it was the correct type it led to a crash in the app due to the prop not receiving the correct type. I looked into it and figured the type for force was not well typed, so here is my proposal.

Added a 3D vector type for the props that expect a 3D vector.
Modified the methods of  ViroNode and ViroButton to match the new force type

I opted to handle the type problem this way so the force prop of physics body and the applyImpulse method match now

This PR solves #337 