### PR TITLE
Fix expo prebuild error by updating withViroAndroid.js

### DIFF
--- a/dist/plugins/withViroAndroid.js
+++ b/dist/plugins/withViroAndroid.js
@@ -112,6 +112,9 @@ const withBranchAndroid = (config) => {
                         // console.log("[VIRO]: \n" + target);
                         data = (0, insertLinesHelper_1.insertLinesHelper)(target, "// add(MyReactNativePackage())", data);
                     }
+                    else if (data.includes("// packages.add(MyReactNativePackage())")) {
+                        data = (0, insertLinesHelper_1.insertLinesHelper)(target, "// packages.add(MyReactNativePackage())", data);
+                    } 
                     else {
                         throw new Error("Unable to insert Android packages into package list. Please create a new issue on GitHub and reference this message!");
                     }


### PR DESCRIPTION
I have no idea what I'm doing but I was running into

`Unable to insert Android packages into package list. Please create a new issue on GitHub and reference this message!`

I printed `data` and saw that it included a subtly different line, `// packages.add(MyReactNativePackage())` (i.e. missing the semicolon)

i don't want to mess with the other `if` statement so I just added a new one