### PR TITLE
Fix quest store submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+## Unreleased
+
+### Fixed
+
+- **Quest builds failed Meta Horizon Store validation on Expo projects.** Two checks the plugin meant to handle never did. The `targetSdkVersion` cap rewrote `app/build.gradle`, but Expo's template resolves targetSdk from `gradle.properties` through `rootProject.ext`, so nothing matched and the APK shipped with targetSdk 36. The GLES `uses-feature` was declared `required="false"`, which the store validator does not count as a graphics API. When `xRMode` includes `"QUEST"`, the plugin now writes `android.targetSdkVersion=34` to `gradle.properties` (only ever lowering it; `android.questTargetSdkVersion` overrides the ceiling) and declares GLES 3.0 as required. Phone-only builds are unchanged.
+
+### Added
+
+- **Quest Store packaging defaults** when `xRMode` includes `"QUEST"`: `reactNativeArchitectures=arm64-v8a` (Quest hardware is 64-bit, the store warns on 32-bit libraries, and dropping the other ABIs roughly halves the APK; opt out with `android.questArm64Only: false`) and a `com.oculus.supportedDevices` manifest entry defaulting to `quest2|questpro|quest3|quest3s` (clears the "Quest 1 is no longer supported" warning; override with `android.questSupportedDevices`).
+
+### Migration
+
+- No breaking changes for phone builds. If an app also sets `android.targetSdkVersion` or `buildArchs` through `expo-build-properties`, the plugin listed earlier in `plugins` wins on the same `gradle.properties` key, because config-plugin mods run in reverse registration order.
+
 ## v2.58.1 — 17 August 2026
 
 ### Fixed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## Unreleased
+
+### Fixed
+
+- **Quest builds failed Meta Horizon Store validation on Expo projects.** The plugin's targetSdk cap never applied on Expo's template and the GLES declaration was optional, which the store reads as missing. With `"QUEST"` in `xRMode` the plugin now sets `android.targetSdkVersion=34` in `gradle.properties` and requires GLES 3.0.
+
+### Added
+
+- **Quest Store packaging defaults**: arm64-only builds (`android.questArm64Only`, default true) and a `com.oculus.supportedDevices` manifest entry (`android.questSupportedDevices`, default `quest2|questpro|quest3|quest3s`).
+
 ## v2.58.1
 
 ### Fixed

--- a/plugins/withViro.ts
+++ b/plugins/withViro.ts
@@ -169,6 +169,27 @@ export interface ViroConfigurationOptions {
      * https://developer.oculus.com/manage
      */
     questAppId?: string;
+    /**
+     * Meta Quest device targeting, written to AndroidManifest as
+     * com.oculus.supportedDevices when xRMode includes "QUEST".
+     *
+     * DEFAULTS TO: "quest2|questpro|quest3|quest3s"
+     */
+    questSupportedDevices?: string;
+    /**
+     * targetSdkVersion ceiling applied when xRMode includes "QUEST". The Meta
+     * Quest Store rejects immersive apps above 34. Only ever lowers the value.
+     *
+     * DEFAULTS TO: 34
+     */
+    questTargetSdkVersion?: number;
+    /**
+     * Build arm64-v8a only when xRMode includes "QUEST". Quest hardware is
+     * 64-bit and the store warns on 32-bit libraries.
+     *
+     * DEFAULTS TO: true
+     */
+    questArm64Only?: boolean;
   };
 }
 

--- a/plugins/withViroAndroid.ts
+++ b/plugins/withViroAndroid.ts
@@ -1,9 +1,11 @@
 import {
+  AndroidConfig,
   ConfigPlugin,
   ExportedConfigWithProps,
   withAndroidManifest,
   withAppBuildGradle,
   withDangerousMod,
+  withGradleProperties,
   withProjectBuildGradle,
   withSettingsGradle,
 } from "@expo/config-plugins";
@@ -385,13 +387,13 @@ const withViroManifest = (config: ExpoConfig) =>
         },
       });
 
-      // Keep GLES 3.0 declared (required=false) so the Quest Store validator
-      // sees a graphics API. Previously tools:node="remove" silently stripped
-      // this entry from the merged manifest entirely.
+      // The Quest Store validator only counts a *required* GLES/Vulkan
+      // declaration; required=false is reported as "no graphics API". Every
+      // Quest has GLES 3, so require it there and keep it optional on phones.
       contents.manifest["uses-feature"].push({
         $: {
           "android:glEsVersion": "0x00030000",
-          "android:required": "false",
+          "android:required": activeXrModes.includes("QUEST") ? "true" : "false",
           "tools:replace": "required",
         },
       });
@@ -706,13 +708,33 @@ class VRActivity : ReactActivity() {
     },
   ]);
 
-  // 2. Cap targetSdkVersion to 34 — Meta Quest Store rejects targetSdk > 34.
-  config = withAppBuildGradle(config, (config) => {
-    config.modResults.contents = config.modResults.contents.replace(
-      /targetSdk(?:Version)?\s*[=\s]\s*(\d+)/g,
-      (match: string, ver: string) =>
-        parseInt(ver, 10) > 34 ? match.replace(ver, "34") : match
+  // 2. Quest Store packaging. Expo's template resolves targetSdk through
+  // rootProject.ext from gradle.properties (`android.targetSdkVersion`), so a
+  // rewrite of app/build.gradle never matched anything. Only ever lower it.
+  // Quest hardware is arm64-only; the other ABIs roughly double the APK and the
+  // store warns on 32-bit libraries.
+  const questTargetSdk = props?.android?.questTargetSdkVersion ?? 34;
+  const questArm64Only = props?.android?.questArm64Only ?? true;
+  config = withGradleProperties(config, (config) => {
+    const current = config.modResults.find(
+      (item) => item.type === "property" && item.key === "android.targetSdkVersion"
     );
+    const currentSdk =
+      current?.type === "property" ? parseInt(current.value, 10) : NaN;
+    if (Number.isNaN(currentSdk) || currentSdk > questTargetSdk) {
+      AndroidConfig.BuildProperties.updateAndroidBuildProperty(
+        config.modResults,
+        "android.targetSdkVersion",
+        String(questTargetSdk)
+      );
+    }
+    if (questArm64Only) {
+      AndroidConfig.BuildProperties.updateAndroidBuildProperty(
+        config.modResults,
+        "reactNativeArchitectures",
+        "arm64-v8a"
+      );
+    }
     return config;
   });
 
@@ -778,6 +800,23 @@ class VRActivity : ReactActivity() {
           },
         });
       }
+    }
+
+    // Without this the store assumes every headset, including the retired
+    // Quest 1, and warns on upload.
+    const supportedDevices =
+      props?.android?.questSupportedDevices ?? "quest2|questpro|quest3|quest3s";
+    if (!app["meta-data"]) app["meta-data"] = [];
+    const alreadyHasDevices = (app["meta-data"] as any[]).some(
+      (m: any) => m.$?.["android:name"] === "com.oculus.supportedDevices"
+    );
+    if (!alreadyHasDevices) {
+      (app["meta-data"] as any[]).push({
+        $: {
+          "android:name": "com.oculus.supportedDevices",
+          "android:value": supportedDevices,
+        },
+      });
     }
 
     return config;


### PR DESCRIPTION
Changes to Quest builds:
- Cap android.targetSdkVersion to 34
- Require GLES by default
- reactNativeArchitectures default is arm64-v8a
- com.oculus.supportedDevices default is quest2|questpro|quest3|quest3s